### PR TITLE
docs(agents): improve agent instructions and update-providers.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,12 @@ This repository manages the generation of CUE schemas for Terraform providers. I
 
 * **`internal/jsonschema/`**: Contains the core implementation for the conversion and generation logic. This is the "engine" of the project.
 * **`internal/ci/`**: Contains CUE files that define GitHub Actions logic. These files generate the actual `.github/workflows/` files.
+* **`internal/analysis/`**: Contains scripts and Go generate directives for provider analysis (e.g. AWS region data). Output is stored in `internal/analysis/out/`.
 * **`[provider]/internal/`**: The workspace for a specific provider's schema extraction.
     * **`corpus.tf`**: Contains the Terraform code that imports the provider. Create this to add a new provider or edit to bump a version manually.
     * **`schema/`**: Contains raw Terraform JSON schemas. **DO NOT ANALYZE** (Too large).
+* **`[provider]/doc.cue`**: User-facing documentation with an example of importing the provider's definitions.
+* **`[provider]/exclude`**: Optional file listing resource name patterns to exclude from generation.
 * **`[provider]/res/` & `[provider]/data/`**: Auto-generated CUE definitions for Resources and Data Sources. **DO NOT ANALYZE** (Too many files).
 
 ---
@@ -50,6 +53,6 @@ To manually trigger a refresh of a provider's CUE definitions:
 
 ## 📝 Development Rules
 * CUE-Driven CI: Do not edit .github/workflows/ directly. Modify the CUE files in internal/ci/ instead.
-  * Use `go generate` to obtain the actual YAML files for GitHub.
+  * Run `go generate ./internal/ci` to regenerate the YAML workflow files.
 * No Manual Edits to Generated Files: Any changes to files in `res/` or `data/` will be overwritten. Fix the generator in the root `internal/` folder instead.
 * Consistency: Always run `cue fmt ./...` after any manual schema generation.

--- a/internal/agent-todo.md
+++ b/internal/agent-todo.md
@@ -10,14 +10,6 @@ Items identified during codebase review that are worth addressing.
 
 ---
 
-## `update-providers.sh`
-
-- **Hardcoded provider list**: The script hardcodes the 7 known providers. Adding a new provider requires editing the script. Consider auto-discovering providers by scanning for directories containing `internal/corpus.tf`.
-- **No incremental runs**: Every invocation regenerates all providers, even if only one `corpus.tf` changed. This makes CI slower than necessary.
-- **Silent grep failures**: `set -e` does not catch all failure modes. Some `grep`-based log checks may pass silently even when generation errors occurred.
-
----
-
 ## `internal/gen/generator.go`
 
 - **Embedded shell script**: The multi-step CUE transformation pipeline (`exportCode` constant) is a raw bash script embedded in a Go string. This is hard to test, debug, and maintain. Extracting it to a `.sh` file or rewriting it using Go APIs would improve reliability.

--- a/internal/agent-todo.md
+++ b/internal/agent-todo.md
@@ -1,0 +1,38 @@
+# Agent TODO: Suggested Improvements
+
+Items identified during codebase review that are worth addressing.
+
+---
+
+## `internal/tf/defs.cue`
+
+- **Ephemeral resource schemas**: There is an existing `TODO` for `ephemeral_resource_schemas`, a newer Terraform feature. Without it, providers that use ephemeral resources may produce silent schema mismatches.
+
+---
+
+## `update-providers.sh`
+
+- **Hardcoded provider list**: The script hardcodes the 7 known providers. Adding a new provider requires editing the script. Consider auto-discovering providers by scanning for directories containing `internal/corpus.tf`.
+- **No incremental runs**: Every invocation regenerates all providers, even if only one `corpus.tf` changed. This makes CI slower than necessary.
+- **Silent grep failures**: `set -e` does not catch all failure modes. Some `grep`-based log checks may pass silently even when generation errors occurred.
+
+---
+
+## `internal/gen/generator.go`
+
+- **Embedded shell script**: The multi-step CUE transformation pipeline (`exportCode` constant) is a raw bash script embedded in a Go string. This is hard to test, debug, and maintain. Extracting it to a `.sh` file or rewriting it using Go APIs would improve reliability.
+- **No incremental/cached generation**: Every run regenerates all definitions from scratch, even when the underlying schema has not changed.
+
+---
+
+## `internal/ci/`
+
+- **No drift check for generated YAML**: If someone modifies CUE files in `internal/ci/` but forgets to run `go generate ./internal/ci`, the committed `.github/workflows/` YAML silently drifts. A CI job that re-generates and diffs would catch this.
+- **`analysis.cue` cadence**: The analysis workflow is `workflow_dispatch`-only with no documented intended cadence. A comment in the CUE file or in AGENTS.md would clarify when it should be run.
+
+---
+
+## General
+
+- **`write_only` Terraform fields**: Fields marked `write_only` in Terraform schemas (e.g. passwords, secrets) cannot be read back from state. They are currently emitted as normal fields, which could mislead consumers of the generated schemas. Consider marking or excluding them.
+- **No `CONTRIBUTING.md`**: The onboarding process for human contributors (add provider, bump version, run tests) is only documented in AGENTS.md. A short `CONTRIBUTING.md` would help.


### PR DESCRIPTION
## Summary

- Expand `AGENTS.md` with missing directory entries (`internal/analysis/`, `doc.cue`, `exclude`) and clarify the `go generate` command for CI workflows
- Add `internal/agent-todo.md` tracking suggested codebase improvements identified during review
- Improve `update-providers.sh`: replace hardcoded provider list with auto-discovery via `*/internal/corpus.tf` glob (skipping large providers `aws`, `google`, `azurerm` in no-arg runs), and replace the confusing `grep || exit 0` pattern with a clearer `grep -q` check

## Test plan

- [ ] Verify `./update-providers.sh <small-provider>` still works for a specific provider
- [ ] Verify `./update-providers.sh` (no args) discovers providers and skips `aws`, `google`, `azurerm`
- [ ] Verify generation errors are still correctly reported in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)