### PR TITLE
internal/ci: add drift check for generated workflow YAML 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,3 +24,22 @@ jobs:
         run: go install cuelang.org/go/cmd/cue
       - name: Execute
         run: go test -count 2 ./...
+  ci-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.25"
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.13.4
+      - name: Set up CUE
+        run: go install cuelang.org/go/cmd/cue
+      - name: Execute
+        run: |-
+          go generate ./internal/ci
+          git diff --exit-code .github/ || (echo "CI workflows are out of date. Run 'go generate ./internal/ci'." && exit 1)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,3 +56,5 @@ To manually trigger a refresh of a provider's CUE definitions:
   * Run `go generate ./internal/ci` to regenerate the YAML workflow files.
 * No Manual Edits to Generated Files: Any changes to files in `res/` or `data/` will be overwritten. Fix the generator in the root `internal/` folder instead.
 * Consistency: Always run `cue fmt ./...` after any manual schema generation.
+* Todo Hygiene: When completing an item from `internal/agent-todo.md`, remove it from the file as part of the same change.
+* Commit Messages: Use a lowercase prefix that maps to the primary directory changed, e.g. `internal/ci:`, `agents:`, `aws:`.

--- a/internal/agent-todo.md
+++ b/internal/agent-todo.md
@@ -19,7 +19,6 @@ Items identified during codebase review that are worth addressing.
 
 ## `internal/ci/`
 
-- **No drift check for generated YAML**: If someone modifies CUE files in `internal/ci/` but forgets to run `go generate ./internal/ci`, the committed `.github/workflows/` YAML silently drifts. A CI job that re-generates and diffs would catch this.
 - **`analysis.cue` cadence**: The analysis workflow is `workflow_dispatch`-only with no documented intended cadence. A comment in the CUE file or in AGENTS.md would clarify when it should be run.
 
 ---

--- a/internal/ci/test.cue
+++ b/internal/ci/test.cue
@@ -5,4 +5,9 @@ workflows: test: {
 	on: pull_request: branches: ["main"]
 
 	jobs: main: #script: "go test -count 2 ./..."
+
+	jobs: "ci-check": #script: """
+		go generate ./internal/ci
+		git diff --exit-code .github/ || (echo "CI workflows are out of date. Run 'go generate ./internal/ci'." && exit 1)
+		"""
 }


### PR DESCRIPTION
Add a ci-check job to the test workflow that re-runs go generate
and fails if the committed .github/ files differ, preventing silent
drift between CUE sources and generated YAML.